### PR TITLE
installing missing less & groff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL maintainer="Bastien Arata <bastyen.a@gmail.com>" \
 ENV PATH="/root/.local/bin:$PATH"
 ENV PYTHONIOENCODING=UTF-8
 
-RUN apk add --no-cache jq
+RUN apk add --no-cache jq less groff
 
 ARG AWS_CLI_VERSION
 


### PR DESCRIPTION
The current version is showing an error message saying `Could not find executable named "groff"`